### PR TITLE
chore(deps): bump node from 18.15.0-bullseye to 20.2.0-bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # First things first, we build an image which is where we're going to compile
 # our static assets with. We use this stage in development.
-FROM node:18.15.0-bullseye as static-deps
+FROM node:20.2.0-bullseye as static-deps
 
 WORKDIR /opt/warehouse/src/
 


### PR DESCRIPTION
Bumps node from 18.15.0-bullseye to 20.2.0-bullseye.

---
updated-dependencies:
- dependency-name: node dependency-type: direct:production update-type: version-update:semver-major ...